### PR TITLE
fix: Remove trailing slash from solutions route to fix 404 error

### DIFF
--- a/apps/web/src/routes/solutions/index.tsx
+++ b/apps/web/src/routes/solutions/index.tsx
@@ -10,7 +10,7 @@ import { Link } from "@tanstack/react-router";
 import { ArrowRight, Truck } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
-export const Route = createFileRoute("/solutions/")({
+export const Route = createFileRoute("/solutions")({
   component: SolutionsComponent,
   head: () => ({
     meta: [


### PR DESCRIPTION
## Summary
- Fixed 404 error when accessing `/solutions/driver-tripbook`
- Removed trailing slash from solutions route definition to match routing pattern

## Test plan
- [x] Start dev server
- [x] Navigate to `/solutions` - should work
- [x] Navigate to `/solutions/driver-tripbook` - should work (previously 404)
- [x] Verify route tree regenerates correctly

Signed-off-by: Siarhei H.