### PR TITLE
fix: Cloudflare Pages deployment and SPA routing fixes

### DIFF
--- a/apps/web/.npmrc
+++ b/apps/web/.npmrc
@@ -1,0 +1,3 @@
+legacy-peer-deps=true
+auto-install-peers=true
+strict-peer-deps=false

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview --port 4173"
   },
   "devDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "^4.28.1",
     "@tanstack/react-query-devtools": "^5.80.5",
     "@tanstack/react-router-devtools": "^1.114.27",
     "@tanstack/router-plugin": "^1.114.27",

--- a/apps/web/src/routes/solutions/index.tsx
+++ b/apps/web/src/routes/solutions/index.tsx
@@ -10,7 +10,7 @@ import { Link } from "@tanstack/react-router";
 import { ArrowRight, Truck } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
-export const Route = createFileRoute("/solutions/")({
+export const Route = createFileRoute("/solutions")({
   component: SolutionsComponent,
   head: () => ({
     meta: [


### PR DESCRIPTION
## Summary
- Added 404.html for GitHub Pages SPA routing support
- Fixed Cloudflare Pages deployment issues with Rollup dependencies
- Added .npmrc configuration for proper npm peer dependency handling

## Changes included
1. **SPA Routing Fix** (#2)
   - Added 404.html to handle client-side routing on static hosts
   - Updated main.tsx to process redirect parameters
   - Enables direct access to routes like `/solutions/driver-tripbook`

2. **Cloudflare Deployment Fix**
   - Added explicit Rollup Linux dependency for Cloudflare build environment
   - Added .npmrc to handle npm peer dependencies
   - Fixes build error: Cannot find module @rollup/rollup-linux-x64-gnu

## Test plan
- [x] Build project locally
- [x] Verify 404.html is in dist folder
- [ ] Deploy to Cloudflare Pages
- [ ] Test direct access to `/solutions/driver-tripbook`
- [ ] Verify build succeeds on Cloudflare

Signed-off-by: Siarhei H.