### PR TITLE
fix: Add Lightning CSS Linux dependency for Cloudflare Pages

### DIFF
--- a/apps/web/.npmrc
+++ b/apps/web/.npmrc
@@ -1,3 +1,4 @@
 legacy-peer-deps=true
 auto-install-peers=true
 strict-peer-deps=false
+optional=true

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.28.1",
+    "lightningcss-linux-x64-gnu": "^1.28.2",
     "@tanstack/react-query-devtools": "^5.80.5",
     "@tanstack/react-router-devtools": "^1.114.27",
     "@tanstack/router-plugin": "^1.114.27",


### PR DESCRIPTION
## Summary
- Added lightningcss-linux-x64-gnu dependency for Tailwind CSS v4 compatibility
- Updated .npmrc to ensure optional dependencies are installed
- Fixes Cloudflare Pages build error

## Problem
Cloudflare Pages build was failing with:
```
Error: Cannot find module '../lightningcss.linux-x64-gnu.node'
```

This occurs because Tailwind CSS v4 uses Lightning CSS for processing, and the Linux binary wasn't being installed in the Cloudflare build environment.

## Solution
- Added `lightningcss-linux-x64-gnu` as an explicit dependency
- Updated .npmrc with `optional=true` to ensure platform-specific dependencies are installed

## Test plan
- [x] Test build locally
- [ ] Deploy to Cloudflare Pages
- [ ] Verify build succeeds without Lightning CSS errors

Signed-off-by: Siarhei H.